### PR TITLE
Use stack itself to get target path

### DIFF
--- a/stack-haddock-upload.sh
+++ b/stack-haddock-upload.sh
@@ -36,7 +36,7 @@ trap 'rm -r "$dir"' EXIT
 stack haddock
 
 #cp -R dist/doc/html/$pkg/ $dir/$pkg-$ver-docs
-cp -R .stack-work/dist/x86_64-linux/Cabal-1.24.0.0/doc/html/$pkg/ $dir/$pkg-$ver-docs
+cp -R $(stack path --local-install-root)/doc/$pkg-$ver/ $dir/$pkg-$ver-docs
 
 tar cvz -C $dir --format=ustar -f $dir/$pkg-$ver-docs.tar.gz $pkg-$ver-docs
 


### PR DESCRIPTION
### Changes

- Use stack to get into the docs dir, no need to hardcode cabal version / path
- Fix docs path: it is `.stack-work/install/x86_64-osx/lts-7.2/8.0.1/<pkg>-<ver>`, not `html/<pkg>`, at least for `GHC8`, `stack 1.2.0`.